### PR TITLE
Rename some ids: com.github.autopkg to com.github.jessepeterson

### DIFF
--- a/CUDA-Z/CUDA-Z.munki.recipe
+++ b/CUDA-Z/CUDA-Z.munki.recipe
@@ -7,7 +7,7 @@
 	<key>Input</key>
 	<dict>
 		<key>IDENTIFIER</key>
-		<string>com.github.autopkg.munki.CUDA-Z</string>
+		<string>com.github.jessepeterson.munki.CUDA-Z</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps</string>
 		<key>NAME</key>

--- a/CitrixReceiver/CitrixReceiver.munki.recipe
+++ b/CitrixReceiver/CitrixReceiver.munki.recipe
@@ -9,7 +9,7 @@
 		<key>DOWNLOAD_URL</key>
 		<string>http://downloadplugins.citrix.com.edgesuite.net/Mac/CitrixReceiverWeb.dmg</string>
 		<key>IDENTIFIER</key>
-		<string>com.github.autopkg.munki.CitrixReceiver</string>
+		<string>com.github.jessepeterson.munki.CitrixReceiver</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>internet_plugins</string>
 		<key>NAME</key>

--- a/GrandPerspective/GrandPerspective.munki.recipe
+++ b/GrandPerspective/GrandPerspective.munki.recipe
@@ -7,7 +7,7 @@
 	<key>Input</key>
 	<dict>
 		<key>IDENTIFIER</key>
-		<string>com.github.autopkg.munki.GrandPerspective</string>
+		<string>com.github.jessepeterson.munki.GrandPerspective</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps</string>
 		<key>NAME</key>

--- a/NVIDIA/CUDADriver.munki.recipe
+++ b/NVIDIA/CUDADriver.munki.recipe
@@ -7,7 +7,7 @@
 	<key>Input</key>
 	<dict>
 		<key>IDENTIFIER</key>
-		<string>com.github.autopkg.munki.CUDADriver</string>
+		<string>com.github.jessepeterson.munki.CUDADriver</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>drivers</string>
 		<key>NAME</key>

--- a/ProjectLibre/ProjectLibre.munki.recipe
+++ b/ProjectLibre/ProjectLibre.munki.recipe
@@ -7,7 +7,7 @@
 	<key>Input</key>
 	<dict>
 		<key>IDENTIFIER</key>
-		<string>com.github.autopkg.munki.ProjectLibre</string>
+		<string>com.github.jessepeterson.munki.ProjectLibre</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps</string>
 		<key>NAME</key>


### PR DESCRIPTION
I'd just made an override of your CUDA recipe (thanks!) and noticed a few recipes using an identifier `com.github.autopkg`, so I've renamed them to your namespace.
