### PR TITLE
Update path for VBoxManage

### DIFF
--- a/Oracle/VirtualBoxExtPack.munki.recipe
+++ b/Oracle/VirtualBoxExtPack.munki.recipe
@@ -70,7 +70,7 @@
 					<key>installcheck_script</key>
 					<string>#!/bin/sh
 
-VBM=/usr/bin/VBoxManage
+VBM="$(which VBoxManage)"
 
 if [ ! -f $VBM ]
 then
@@ -106,7 +106,7 @@ exit 1</string>
 					<key>postinstall_script</key>
 					<string>#!/bin/sh
 
-VBM=/usr/bin/VBoxManage
+VBM="$(which VBoxManage)"
 
 if [ ! -f $VBM ]
 then


### PR DESCRIPTION
Updated path for VBM to pull from "which VBoxManage". The static path /usr/bin/ was incorrect for my install which has that in /usr/local/bin. Pulling this from the results of "which VBoxManage" should give more reliable results?